### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ Designed by [colorlib](https://colorlib.com/wp/template/responsive-table-v2/).
 | [datashaper](https://anaconda.org/conda-forge/datashaper) | [![conda](https://anaconda.org/conda-forge/datashaper/badges/downloads.svg)](https://anaconda.org/conda-forge/datashaper) |
 | [ccx2paraview](https://anaconda.org/conda-forge/ccx2paraview) | [![conda](https://anaconda.org/conda-forge/ccx2paraview/badges/downloads.svg)](https://anaconda.org/conda-forge/ccx2paraview) |
 | [python-zstd](https://anaconda.org/conda-forge/python-zstd) | [![conda](https://anaconda.org/conda-forge/python-zstd/badges/downloads.svg)](https://anaconda.org/conda-forge/python-zstd) |
-| [pyautogen](https://anaconda.org/conda-forge/pyautogen) | [![conda](https://anaconda.org/conda-forge/pyautogen/badges/downloads.svg)](https://anaconda.org/conda-forge/pyautogen) |
+| [ag2](https://anaconda.org/conda-forge/ag2) | [![conda](https://anaconda.org/conda-forge/ag2/badges/downloads.svg)](https://anaconda.org/conda-forge/ag2) |
 | [diffeqpy](https://anaconda.org/conda-forge/diffeqpy) | [![conda](https://anaconda.org/conda-forge/diffeqpy/badges/downloads.svg)](https://anaconda.org/conda-forge/diffeqpy) |
 | [pyrms](https://anaconda.org/conda-forge/pyrms) | [![conda](https://anaconda.org/conda-forge/pyrms/badges/downloads.svg)](https://anaconda.org/conda-forge/pyrms) |
 | [mediawikiapi](https://anaconda.org/conda-forge/mediawikiapi) | [![conda](https://anaconda.org/conda-forge/mediawikiapi/badges/downloads.svg)](https://anaconda.org/conda-forge/mediawikiapi) |

--- a/packages.md
+++ b/packages.md
@@ -886,7 +886,7 @@
 | [datashaper](https://anaconda.org/conda-forge/datashaper) | [![conda](https://anaconda.org/conda-forge/datashaper/badges/downloads.svg)](https://anaconda.org/conda-forge/datashaper) |
 | [ccx2paraview](https://anaconda.org/conda-forge/ccx2paraview) | [![conda](https://anaconda.org/conda-forge/ccx2paraview/badges/downloads.svg)](https://anaconda.org/conda-forge/ccx2paraview) |
 | [python-zstd](https://anaconda.org/conda-forge/python-zstd) | [![conda](https://anaconda.org/conda-forge/python-zstd/badges/downloads.svg)](https://anaconda.org/conda-forge/python-zstd) |
-| [pyautogen](https://anaconda.org/conda-forge/pyautogen) | [![conda](https://anaconda.org/conda-forge/pyautogen/badges/downloads.svg)](https://anaconda.org/conda-forge/pyautogen) |
+| [ag2](https://anaconda.org/conda-forge/ag2) | [![conda](https://anaconda.org/conda-forge/ag2/badges/downloads.svg)](https://anaconda.org/conda-forge/ag2) |
 | [diffeqpy](https://anaconda.org/conda-forge/diffeqpy) | [![conda](https://anaconda.org/conda-forge/diffeqpy/badges/downloads.svg)](https://anaconda.org/conda-forge/diffeqpy) |
 | [pyrms](https://anaconda.org/conda-forge/pyrms) | [![conda](https://anaconda.org/conda-forge/pyrms/badges/downloads.svg)](https://anaconda.org/conda-forge/pyrms) |
 | [mediawikiapi](https://anaconda.org/conda-forge/mediawikiapi) | [![conda](https://anaconda.org/conda-forge/mediawikiapi/badges/downloads.svg)](https://anaconda.org/conda-forge/mediawikiapi) |


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
